### PR TITLE
The touch trigger should update the timestamp column when it is currently NULL

### DIFF
--- a/lib/sequel_postgresql_triggers.rb
+++ b/lib/sequel_postgresql_triggers.rb
@@ -126,11 +126,11 @@ module Sequel
         sql = <<-SQL
           BEGIN
             IF (TG_OP = 'INSERT') THEN
-              UPDATE #{quote_schema_table(touch_table)} SET #{quote_identifier(column)} = CURRENT_TIMESTAMP WHERE #{cond['NEW']} AND #{quote_identifier(column)} <> CURRENT_TIMESTAMP;
+              UPDATE #{quote_schema_table(touch_table)} SET #{quote_identifier(column)} = CURRENT_TIMESTAMP WHERE #{cond['NEW']} AND ((#{quote_identifier(column)} <> CURRENT_TIMESTAMP) OR (#{quote_identifier(column)} IS NULL));
             ELSIF (TG_OP = 'UPDATE') THEN
-              UPDATE #{quote_schema_table(touch_table)} SET #{quote_identifier(column)} = CURRENT_TIMESTAMP WHERE #{cond['NEW']} AND #{quote_identifier(column)} <> CURRENT_TIMESTAMP;
+              UPDATE #{quote_schema_table(touch_table)} SET #{quote_identifier(column)} = CURRENT_TIMESTAMP WHERE #{cond['NEW']} AND ((#{quote_identifier(column)} <> CURRENT_TIMESTAMP) OR (#{quote_identifier(column)} IS NULL));
             ELSIF (TG_OP = 'DELETE') THEN
-              UPDATE #{quote_schema_table(touch_table)} SET #{quote_identifier(column)} = CURRENT_TIMESTAMP WHERE #{cond['OLD']} AND #{quote_identifier(column)} <> CURRENT_TIMESTAMP;
+              UPDATE #{quote_schema_table(touch_table)} SET #{quote_identifier(column)} = CURRENT_TIMESTAMP WHERE #{cond['OLD']} AND ((#{quote_identifier(column)} <> CURRENT_TIMESTAMP) OR (#{quote_identifier(column)} IS NULL));
             END IF;
             RETURN NULL;
           END;

--- a/spec/sequel_postgresql_triggers_spec.rb
+++ b/spec/sequel_postgresql_triggers_spec.rb
@@ -220,5 +220,14 @@ describe "PostgreSQL Triggers" do
       DB[:children].delete
       DB[:parents].get(:changed_on).should > time
     end
+
+    specify "Should update the timestamp on the related table if that timestamp is initially NULL" do
+      DB.pgt_touch(:children, :parents, :changed_on, :id1=>:parent_id1)
+      DB[:parents] << {:id1=>1, :changed_on=>nil}
+      DB[:children] << {:id=>1, :parent_id1=>1}
+      changed_on = DB[:parents].get(:changed_on)
+      changed_on.should_not == nil
+      changed_on.strftime('%F').should == Date.today.strftime('%F')
+    end
   end
 end


### PR DESCRIPTION
The `column_name <> CURRENT_TIMESTAMP` behaves unexpectedly when `column_name` is NULL so if your timestamp columns start out as null then the timestamp is never updated by the trigger.

On postgres 9.2.4:

```
spgt_test=# select NULL <> CURRENT_TIMESTAMP as result;
result 
--------

(1 row)
```
