### PR TITLE
Fix typo in PostgreSQL JSON Audit Logging spec

### DIFF
--- a/spec/sequel_postgresql_triggers_spec.rb
+++ b/spec/sequel_postgresql_triggers_spec.rb
@@ -624,7 +624,7 @@ describe "PostgreSQL JSON Audit Logging" do
     DB.drop_function(:spgt_audit_log)
   end
 
-  it "should previous values in JSON format for inserts and updates" do
+  it "should previous values in JSON format for updates and deletes" do
     @logs.first.must_be_nil
 
     @ds.update(:id=>2, :a=>3)


### PR DESCRIPTION
Fixed a small typo that made me think it would log the inserts to a table.