### PR TITLE
Adds pgt_outbox_setup and pgt_outbox_events for Transactional Outbox Pattern

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -265,6 +265,55 @@ function :: The name of the trigger function to call to log changes
 Note that it is probably a bad idea to use the same table argument
 to both +pgt_json_audit_log_setup+ and +pgt_json_audit_log+.
 
+=== Transactional Outbox Events - pgt_outbox_setup and pgt_outbox_events
+
+These methods setup an outbox table and write events to it when
+writes happen to the watched table.
+
+==== pgt_outbox_setup
+
+This creates an outbox table and a trigger function that will write
+event data to the outbox table. This returns the name of the
+trigger function created, which should be passed to
++pgt_outbox_events+.
+
+Arguments:
+table :: The name of the table storing the audit logs.
+
+Options:
+function_name :: The name of the trigger function
+outbox_table :: The name for the outbox table. Defaults to table_outbox
+event_prefix :: The prefix to use for event_type, defaults to table_ (table_updated, table_created, table_deleted)
+boolean_completed_column :: If this is true, the :completed column will be boolean, otherwise it will be timestamptz
+uuid_primary_key :: Use a uuid type for the primary key of the outbox table
+uuid_function :: The pl/pgsql function name to use for generating a uuid pkey. defaults to :generate_uuid_v4
+function_opts :: Options to pass to +create_function+ when creating the trigger function.
+Column Name Options: (column type in parenthesis)
+created_column :: defaults to :created (timestamptz)
+updated_column :: defaults to :updated (timestamptz)
+attempts_column :: defaults to :attempts (Integer)
+attempted_column :: defaults to :attempted (timestamptz)
+completed_column :: defaults to :completed (Boolean or timestamptz, depending on :boolean_completed_column)
+event_type_column :: defaults to :event_type (String)
+last_error_column :: defaults to :last_error (String)
+data_before_column :: defaults to :data_before (jsonb)
+data_after_column :: defaults to :data_after (jsonb)
+metadata_column :: defaults to :metadata (jsonb)
+
+==== pgt_outbox_events
+
+This adds a trigger to the table that will store events in the outbox table
+when updates occur on the table (and match the filter).
+
+Arguments:
+table :: The name of the table to audit
+function :: The name of the trigger function to call to log changes (usually returned from pgt_outbox_setup)
+
+Options:
+events :: The events to care about. Defaults to [:updated, :deleted, :created] (all writes)
+trigger_name :: The name for the trigger
+when :: A filter for the trigger, where clause if you will
+
 == Caveats
 
 If you have defined counter or sum cache triggers using this library

--- a/README.rdoc
+++ b/README.rdoc
@@ -284,16 +284,16 @@ Options:
 function_name :: The name of the trigger function
 outbox_table :: The name for the outbox table. Defaults to table_outbox
 event_prefix :: The prefix to use for event_type, defaults to table_ (table_updated, table_created, table_deleted)
-boolean_completed_column :: If this is true, the :completed column will be boolean, otherwise it will be timestamptz
+boolean_completed_column :: If this is true, the :completed column will be boolean, otherwise it will be Time
 uuid_primary_key :: Use a uuid type for the primary key of the outbox table
 uuid_function :: The pl/pgsql function name to use for generating a uuid pkey. defaults to :generate_uuid_v4
 function_opts :: Options to pass to +create_function+ when creating the trigger function.
 Column Name Options: (column type in parenthesis)
-created_column :: defaults to :created (timestamptz)
-updated_column :: defaults to :updated (timestamptz)
+created_column :: defaults to :created (Time)
+updated_column :: defaults to :updated (Time)
 attempts_column :: defaults to :attempts (Integer)
-attempted_column :: defaults to :attempted (timestamptz)
-completed_column :: defaults to :completed (Boolean or timestamptz, depending on :boolean_completed_column)
+attempted_column :: defaults to :attempted (Time)
+completed_column :: defaults to :completed (Boolean or Time, depending on :boolean_completed_column)
 event_type_column :: defaults to :event_type (String)
 last_error_column :: defaults to :last_error (String)
 data_before_column :: defaults to :data_before (jsonb)

--- a/README.rdoc
+++ b/README.rdoc
@@ -286,7 +286,7 @@ outbox_table :: The name for the outbox table. Defaults to table_outbox
 event_prefix :: The prefix to use for event_type, defaults to table_ (table_updated, table_created, table_deleted)
 boolean_completed_column :: If this is true, the :completed column will be boolean, otherwise it will be Time
 uuid_primary_key :: Use a uuid type for the primary key of the outbox table
-uuid_function :: The pl/pgsql function name to use for generating a uuid pkey. defaults to :generate_uuid_v4
+uuid_function :: The pl/pgsql function name to use for generating a uuid pkey. defaults to :uuid_generate_v4
 function_opts :: Options to pass to +create_function+ when creating the trigger function.
 Column Name Options: (column type in parenthesis)
 created_column :: defaults to :created (Time)

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -332,6 +332,7 @@ module Sequel
         event_type_column = opts.fetch(:event_type_column, :event_type)
         data_after_column = opts.fetch(:data_after_column, :data_after)
         data_before_column = opts.fetch(:data_before_column, :data_before)
+        attempted_column = opts.fetch(:attempted_column, :attempted)
         boolean_completed_column = opts.fetch(:boolean_completed_column, false)
         uuid_primary_key = opts.fetch(:uuid_primary_key, false)
         run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_primary_key
@@ -345,7 +346,7 @@ module Sequel
           Integer opts.fetch(:attempts_column, :attempts), null: false, default: 0
           Time created_column
           Time updated_column
-          Time opts.fetch(:attempted_column, :attempted)
+          Time attempted_column
           if boolean_completed_column
             FalseClass opts.fetch(:completed_column, :completed), null: false, default: false
           else

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -329,10 +329,14 @@ module Sequel
         event_prefix  = opts.fetch(:event_prefix, table)
         created_column = opts.fetch(:created_column, :created)
         updated_column = opts.fetch(:updated_column, :updated)
+        completed_column = opts.fetch(:completed_column, :completed)
+        attempts_column = opts.fetch(:attempts_column, :attempts)
+        attempted_column = opts.fetch(:attempted_column, :attempted)
         event_type_column = opts.fetch(:event_type_column, :event_type)
+        last_error_column = opts.fetch(:last_error_column, :last_error)
         data_after_column = opts.fetch(:data_after_column, :data_after)
         data_before_column = opts.fetch(:data_before_column, :data_before)
-        attempted_column = opts.fetch(:attempted_column, :attempted)
+        metadata_column = opts.fetch(:metadata_column, :metadata)
         boolean_completed_column = opts.fetch(:boolean_completed_column, false)
         uuid_primary_key = opts.fetch(:uuid_primary_key, false)
         run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_primary_key
@@ -343,20 +347,20 @@ module Sequel
           else
             primary_key :id
           end
-          Integer opts.fetch(:attempts_column, :attempts), null: false, default: 0
+          Integer attempts_column, null: false, default: 0
           Time created_column
           Time updated_column
           Time attempted_column
           if boolean_completed_column
-            FalseClass opts.fetch(:completed_column, :completed), null: false, default: false
+            FalseClass completed_column, null: false, default: false
           else
-            Time opts.fetch(:completed_column, :completed)
+            Time completed_column
           end
           String event_type_column, null: false
-          String opts.fetch(:last_error_column, :last_error)
+          String last_error_column
           jsonb data_before_column
           jsonb data_after_column
-          jsonb opts.fetch(:metadata_column, :metadata)
+          jsonb metadata_column
           index Sequel.asc(created_column)
           index Sequel.desc(attempted_column)
         end

--- a/spec/sequel_postgresql_triggers_spec.rb
+++ b/spec/sequel_postgresql_triggers_spec.rb
@@ -876,7 +876,7 @@ describe "PostgreSQL Transactional Outbox With UUID Pkey" do
   end
 end if DB.server_version >= 90400
 
-describe "PostgreSQL Transactional Outbox With UUID Pkey" do
+describe "PostgreSQL Transactional Outbox With Boolean :completed field" do
   before do
     DB.extension :pg_json
     DB.create_table(:accounts){integer :id; String :s}

--- a/spec/sequel_postgresql_triggers_spec.rb
+++ b/spec/sequel_postgresql_triggers_spec.rb
@@ -25,7 +25,7 @@ if ENV['PGT_GLOBAL'] == '1'
   require 'sequel_postgresql_triggers'
 else
   puts "Running specs with extension"
-  DB.extension :pg_triggers
+  DB.extension :pg_triggers 
 end
 DB.extension :pg_array
 
@@ -59,31 +59,31 @@ describe "PostgreSQL Counter Cache Trigger" do
 
     DB[:entries].insert(:id=>2, :account_id=>1)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [2, 0]
-
+    
     DB[:entries].insert(:id=>3, :account_id=>nil)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [2, 0]
-
+    
     DB[:entries].where(:id=>3).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [2, 1]
-
+    
     DB[:entries].where(:id=>2).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 2]
-
+    
     DB[:entries].where(:id=>2).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-
+    
     DB[:entries].where(:id=>2).update(:id=>4)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-
+    
     DB[:entries].where(:id=>4).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 2]
-
+    
     DB[:entries].where(:id=>4).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-
+    
     DB[:entries].filter(:id=>4).delete
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-
+    
     DB[:entries].delete
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [0, 0]
   end
@@ -195,34 +195,34 @@ describe "PostgreSQL Sum Cache Trigger" do
 
     DB[:entries].insert(:id=>2, :account_id=>1, :amount=>200)
     DB[:accounts].order(:id).select_map(:balance).must_equal [300, 0]
-
+    
     DB[:entries].insert(:id=>3, :account_id=>nil, :amount=>500)
     DB[:accounts].order(:id).select_map(:balance).must_equal [300, 0]
-
+    
     DB[:entries].where(:id=>3).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:balance).must_equal [300, 500]
-
+    
     DB[:entries].exclude(:id=>2).update(:amount=>Sequel.*(:amount, 2))
     DB[:accounts].order(:id).select_map(:balance).must_equal [400, 1000]
-
+    
     DB[:entries].where(:id=>2).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1200]
-
+    
     DB[:entries].where(:id=>2).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-
+    
     DB[:entries].where(:id=>2).update(:id=>4)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-
+    
     DB[:entries].where(:id=>4).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1200]
-
+    
     DB[:entries].where(:id=>4).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-
+    
     DB[:entries].filter(:id=>4).delete
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-
+    
     DB[:entries].delete
     DB[:accounts].order(:id).select_map(:balance).must_equal [0, 0]
   end
@@ -747,6 +747,7 @@ describe "PostgreSQL Force Defaults Trigger" do
     DB[:accounts].first.must_equal(:id=>10, :a=>1, :b=>"'\\a", :c=>nil, :d=>14)
   end
 end
+
 
 describe "PostgreSQL JSON Audit Logging" do
   before do


### PR DESCRIPTION
This adds two new methods, which implement the transactional
outbox pattern utilizing postgresql triggers.

This only handles creating the outbox table, and writing events
to the outbox for table changes, no other part of the system.

Context:
* https://event-driven.io/en/outbox_inbox_patterns_and_delivery_guarantees_explained/
* https://gitlab.com/os85/tobox#usage
